### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - run: pip install -r requirements.txt
+    - run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 Flask-SQLAlchemy
 Flask-WTF
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pytest
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from app import app as flask_app
+from models import db
+
+@pytest.fixture
+def app():
+    flask_app.config['TESTING'] = True
+    flask_app.config['WTF_CSRF_ENABLED'] = False
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with flask_app.app_context():
+        db.drop_all()
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,28 @@
+from models import db, MaintenanceLog
+
+
+def test_add_log(client):
+    response = client.post('/add', data={
+        'part': 'test part',
+        'mileage': 1000,
+        'notes': 'test notes'
+    }, follow_redirects=False)
+    assert response.status_code == 302  # redirect to index
+    with client.application.app_context():
+        count = MaintenanceLog.query.count()
+        assert count == 1
+
+
+def test_list_logs(client):
+    # add an entry first
+    client.post('/add', data={'part': 'oil', 'mileage': 100, 'notes': ''})
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b'oil' in response.data
+
+
+def test_invalid_input(client):
+    response = client.post('/add', data={'part': '', 'mileage': 50, 'notes': ''})
+    assert response.status_code == 200  # form re-rendered due to validation error
+    with client.application.app_context():
+        assert MaintenanceLog.query.count() == 0


### PR DESCRIPTION
## Summary
- add pytest fixtures for Flask test client
- test adding, listing, and rejecting invalid maintenance logs
- install pytest dependency
- run tests in GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b25644eac832891553e54986aa8ad